### PR TITLE
Replace language text with emoji flags

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             </a>
             <div class="nav-icons">
                 <span id="lang-bs" class="flag active">🇧🇦</span>
-                <span id="lang-en" class="flag">ENG</span>
+                <span id="lang-en" class="flag">🇬🇧</span>
                 <button class="hamburger" id="hamburger">
                     <span></span><span></span><span></span>
                 </button>

--- a/prednosti.html
+++ b/prednosti.html
@@ -17,7 +17,7 @@
             </a>
             <div class="nav-icons">
                 <span id="lang-bs" class="flag active">🇧🇦</span>
-                <span id="lang-en" class="flag">ENG</span>
+                <span id="lang-en" class="flag">🇬🇧</span>
                 <button class="hamburger" id="hamburger">
                     <span></span><span></span><span></span>
                 </button>

--- a/style.css
+++ b/style.css
@@ -117,10 +117,9 @@ nav.container {
 }
 
 #lang-en {
-    font-size: 0.80rem; /* Fine-tuned for visual balance with emoji */
-    font-weight: 600;
+    font-size: 1.0rem;
     position: relative;
-    top: -8.50px; /* Minor adjustment for vertical centering */
+    top: -10px;
 }
 
 #lang-bs {

--- a/whitepaper.html
+++ b/whitepaper.html
@@ -17,7 +17,7 @@
             </a>
             <div class="nav-icons">
                 <span id="lang-bs" class="flag active">🇧🇦</span>
-                <span id="lang-en" class="flag">ENG</span>
+                <span id="lang-en" class="flag">🇬🇧</span>
                 <button class="hamburger" id="hamburger">
                     <span></span><span></span><span></span>
                 </button>


### PR DESCRIPTION
## Summary
- show emoji flags instead of text for language switching
- adjust style for English flag icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0ec95cf88324a2d8d99b24f92699