### PR TITLE
Embed video in contact sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,11 @@
                     <div class="form-group">
                         <textarea name="message" rows="4" placeholder="Vaša poruka" required data-lang="contactMessagePlaceholder"></textarea>
                     </div>
-                    <button type="submit" class="btn" data-lang="contactSendButton">Pošalji poruku</button>
+                <button type="submit" class="btn" data-lang="contactSendButton">Pošalji poruku</button>
                 </form>
+                <div class="video-wrapper">
+                    <iframe src="https://www.youtube.com/embed/8Ykhc2iXFho" title="JusticeFusion demo video" allowfullscreen></iframe>
+                </div>
             </section>
 
             <div class="container">

--- a/prednosti.html
+++ b/prednosti.html
@@ -82,6 +82,9 @@
                 </div>
                 <button type="submit" class="btn" data-lang="contactSendButton">Pošalji poruku</button>
             </form>
+            <div class="video-wrapper">
+                <iframe src="https://www.youtube.com/embed/8Ykhc2iXFho" title="JusticeFusion demo video" allowfullscreen></iframe>
+            </div>
         </section>
     </main>
 

--- a/style.css
+++ b/style.css
@@ -380,6 +380,23 @@ section h2, .section-title-linkable a { /* For clickable section titles */
     font-size: 1.2rem;
 }
 
+/* Responsive video wrapper for embedded videos */
+.video-wrapper {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    height: 0;
+    overflow: hidden;
+    margin-top: 1rem;
+}
+.video-wrapper iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
 
 /* About Section / Advantages Section */
 #about-assistant, #prednosti-chatgpt-section {

--- a/whitepaper.html
+++ b/whitepaper.html
@@ -143,6 +143,9 @@
                 </div>
                 <button type="submit" class="btn" data-lang="contactSendButton">Pošalji poruku</button>
             </form>
+            <div class="video-wrapper">
+                <iframe src="https://www.youtube.com/embed/8Ykhc2iXFho" title="JusticeFusion demo video" allowfullscreen></iframe>
+            </div>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- add responsive video wrapper style
- embed YouTube demo video after contact forms across the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852a3309cf08324803105857c6ec09c